### PR TITLE
bump: Update codacy-engine-scala-seed to 6.1.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "codacy-deadcode"
 scalaVersion := "2.12.12"
 
 libraryDependencies ++= Seq(
-  "com.codacy" %% "codacy-engine-scala-seed" % "5.0.2",
+  "com.codacy" %% "codacy-engine-scala-seed" % "6.1.4",
   "com.github.pathikrit" %% "better-files" % "3.9.1"
 ).map(_.withSources())
 

--- a/src/main/scala/com/codacy/tools/deadcode/Deadcode.scala
+++ b/src/main/scala/com/codacy/tools/deadcode/Deadcode.scala
@@ -42,7 +42,7 @@ object Deadcode extends Tool {
   private def filterResultsForFiles(results: List[Result], filesOpt: Option[Set[Source.File]]): List[Result] = {
     filesOpt.fold(results) { files =>
       results.collect {
-        case res: Result.Issue if files.contains(res.file) => res
+        case res: Result.Issue if files.contains(res.filename) => res
       }
     }
   }


### PR DESCRIPTION
## Summary
- Bumps `com.codacy %% codacy-engine-scala-seed` from `5.0.2` to `6.1.4` (latest published tag on [codacy/codacy-engine-scala-seed](https://github.com/codacy/codacy-engine-scala-seed)).
- This version transitively bumps `codacy-plugins-api` to `8.1.1`, which renames `Result.Issue.file` to `Result.Issue.filename`. Updated the single call site in `Deadcode.scala`.
- Checked all other version-encoding files per the README's Agent Playbook:
  - `Dockerfile` base images (`golang:1.17.2-alpine3.14`, `amazoncorretto:8-alpine3.14-jre`) and the unpinned `go get -u` line — no newer pin convention found, left as-is.
  - `.circleci/config.yml` orbs `codacy/base@13.1.1` and `codacy/plugins-test@2.1.2` — already the latest versions in use across `codacy/*` repos, no bump needed.
  - `patterns.json`/`description.json` — unchanged (pattern set didn't change).

## Test plan
All steps from the README's Agent Playbook were run locally:
- [x] `sbt "scalafmt::test; test:scalafmt::test; sbt:scalafmt::test; test"` — all 8 unit tests pass, formatting clean.
- [x] `sbt universal:stage && docker build -t codacy-deadcode .` — image builds successfully.
- [x] `codacy-plugins-test` `json`, `pattern`, and `multiple` suites run against the built image (via a local clone of `codacy/codacy-plugins-test`, since those commands are its own sbt project, not this repo's) — all pass:
  - JsonTests: patterns.json / description.json / deadcode.md read successfully.
  - PatternTests: pass.
  - MultipleTests: `with-config` (2 results), `without-config` (2 results), `with-invalid-param` (0 results) — all as expected.

CI checks will be monitored after opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)